### PR TITLE
Add OpenAPI schema and Swagger UI integration

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="VcsDirectoryMappings" defaultProject="true" />
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
 </project>

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -37,7 +37,9 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'core'
+    'core',
+    'rest_framework',
+    'drf_spectacular'
 ]
 
 MIDDLEWARE = [
@@ -127,3 +129,7 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 AUTH_USER_MODEL = 'core.User'
+
+rest_framework = {
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -130,6 +130,6 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 AUTH_USER_MODEL = 'core.User'
 
-rest_framework = {
+REST_FRAMEWORK = {
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }

--- a/app/app/urls.py
+++ b/app/app/urls.py
@@ -16,6 +16,13 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularSwaggerView
+)
+
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/schema/', SpectacularAPIView.as_view(), name='api-schema'),
+    path('api/docs/', SpectacularSwaggerView.as_view(url_name='api-schema'), name='api-docs'),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django>=4.0.4,<4.1
 djangorestframework>=3.13.1,<3.14
 psycopg2>=2.9.3,<2.10
+drf-spectacular>=0.28,<0.29


### PR DESCRIPTION
**Description:**
- Configured Django to expose an OpenAPI schema with DRF Spectacular.
- Added routes for schema generation and Swagger UI documentation.
- Fixed a case sensitivity issue in the REST framework configuration.